### PR TITLE
test: respect TF_ACC env var for acceptance testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ go test -v -run TestAccEnvironmentVariableDataSource ./internal/provider/
 
 ## Key Patterns
 
-- **Tests use `IsUnitTest: true`** — acceptance tests run without `TF_ACC=1` because of this flag; `make test` runs them all.
+- **Tests adapt to environment** — `IsUnitTest` is set based on `TF_ACC` environment variable. Runs in-process without `TF_ACC`, and as acceptance tests with `TF_ACC=1`.
 - **`sensitiveVariableDataSource.Read` delegates to `NewVariableDataSource().Read()`** — the only difference between the two data sources is `Sensitive: true` on the `value` schema attribute.
 - **`id` is always set equal to `name`** — this is the convention for both data sources.
 - **`go generate`** runs two things: `terraform fmt -recursive ./examples/` and `tfplugindocs` — run it after changing schemas or examples.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ terraform init && terraform plan
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-* [Go](https://golang.org/doc/install) >= 1.19
+* [Go](https://golang.org/doc/install) >= 1.25
 
 ## Building the Provider
 

--- a/internal/provider/sensitive_variable_data_source_test.go
+++ b/internal/provider/sensitive_variable_data_source_test.go
@@ -17,7 +17,7 @@ data "environment_sensitive_variable" "path" {
 
 func TestAccEnvironmentSensitiveVariableDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		IsUnitTest:               true,
+		IsUnitTest:               os.Getenv("TF_ACC") == "",
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/variable_data_source_test.go
+++ b/internal/provider/variable_data_source_test.go
@@ -17,7 +17,7 @@ data "environment_variable" "path" {
 
 func TestAccEnvironmentVariableDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		IsUnitTest:               true,
+		IsUnitTest:               os.Getenv("TF_ACC") == "",
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -48,7 +48,7 @@ func TestAccEnvironmentVariableDataSource_ErrorPaths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Unsetenv(tt.varName)
 			resource.Test(t, resource.TestCase{
-				IsUnitTest:               true,
+				IsUnitTest:               os.Getenv("TF_ACC") == "",
 				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 				Steps: []resource.TestStep{
 					{


### PR DESCRIPTION
Updates the test configuration to toggle IsUnitTest based on the presence of the TF_ACC environment variable. This allows running real acceptance tests against the built binary when TF_ACC is set.

Also updates the Go version requirement in README.md and updates AGENTS.md to reflect the new testing pattern.